### PR TITLE
Fix sidebar

### DIFF
--- a/css/alx-dark.css
+++ b/css/alx-dark.css
@@ -239,10 +239,6 @@ body.dark .navigation>ul>li a .image
   transition: background-color 200ms ease, color 200ms ease, transition 200ms;
 }
 
-body.dark .navigation>ul>li {
-  margin: 0;
-}
-
 body.dark .slack {
   transition: transform 300ms ease-in-out, background-color 300ms ease !important;
 }

--- a/css/alx-dark.css
+++ b/css/alx-dark.css
@@ -155,7 +155,7 @@ body.dark .sidebar>ul>li:last-child {
 body.dark .sidebar {
   background-color: var(--col-bg-400) !important;
   border-right: none !important;
-  filter: drop-shadow(0px 0px 2px var(--col-bg-400)) !important;
+  box-shadow: 0 0 1px 5px var(--col-bg-400);
 }
 
 body.dark .logo {


### PR DESCRIPTION
The code changes resolves a bug a came across earlier today.

Issues found were:
* The sidebar would scroll into the `My Profile` and `Slack` navigation items. 
* Some sidebar items were overlapped with `My Profile` and `Slack`
Issues were cause by a `filter` that was applied to create a glass effect for the sidebar.

Solution:
Replaced the `filter` property to the `box-shadow` property.


Sample photo - The items to the left highlights the bug and the one's to the right highlights the fix

![bug fix](https://user-images.githubusercontent.com/104218489/233235802-0bee07a6-78c7-4c56-92e8-8bfb58f7dcb9.png)
