### PR TITLE
Fix sidebar

### DIFF
--- a/css/alx-dark.css
+++ b/css/alx-dark.css
@@ -62,13 +62,6 @@ body.dark a i {
   color: var(--col-light-500) !important;
 }
 
-body.dark #captains_log_alert {
-  background-color: var(--col-acc-400) !important;
-  border-bottom: 1px solid var(--col-acc-400) !important;
-  filter: drop-shadow(0 0 -1px var(--col-bg-400)) !important;
-  color: var(--col-light-500) !important;
-}
-
 @media (max-width: 767px) {
   body.dark #captains_log_alert {
     filter: drop-shadow(0 0 10px var(--col-bg-400)) !important;
@@ -654,6 +647,16 @@ body.dark .btn-primary {
 /* My Profile styles ends here */
 
 /* Captains log stlye */
+body.dark #captains_log_alert {
+  background-color: var(--col-acc-400) !important;
+  border-bottom: 1px solid var(--col-acc-400) !important;
+  filter: drop-shadow(0 0 -1px var(--col-bg-400)) !important;
+}
+
+body.dark #captains_log_alert > a {
+  color: var(--col-light-500) !important;
+}
+
 body.dark .alert-success {
   background-color: var(--col-bg-400) !important;
   border-color: var(--col-bg-800) !important;

--- a/css/alx-dark.css
+++ b/css/alx-dark.css
@@ -249,6 +249,14 @@ body.dark .slack {
     transform: rotate(170deg);
   }
 }
+
+body.dark .navbar-fixed-top > .navigation > ul > li {
+  margin: 0 !important;
+}
+
+body.dark .navbar-fixed-top > .navigation > ul > li > a {
+  padding: 13px 13px !important;
+}
 /* Navigation styles ends here */
 
 /* Main styles */


### PR DESCRIPTION
There's two major fixes in this PR.

* fbc5f54aa77d490b5a18835b01ce43c3148ea596 Was implemented on the anchor tags to ensure the navigation bar (for smaller viewports) had enough spacing around them. And also to create a consistent background for the navigation items and a separate background for the other sections in the navigation bar (like the slack item in the navigation)
* Noticed Captain's Log text color was extremely hard to see so it's resolved with e4192447d4e376c2a281117e9f09d793efc12d94

![image](https://user-images.githubusercontent.com/104218489/233528307-94c94e06-8b8e-4f28-b7f0-62a034e75114.png)

to

![image](https://user-images.githubusercontent.com/104218489/233528382-8afc3a12-2442-4d5d-8d8a-f4e1e13d4960.png)
