### PR TITLE
👨‍💻 Manage code colors

### DIFF
--- a/css/alx-dark.css
+++ b/css/alx-dark.css
@@ -8,8 +8,12 @@
   --col-bg-800: #383A40;
 
   /* Accent colors */
-  --col-acc-400: #db3e3e;
+  --col-acc-400: #df3e3e;
   --col-acc-500: #f36262;
+
+  /* Code custom colors*/
+  --col-code-color: #DD9444;
+  --col-code-bg: #2B2D30;
 
   /* Colors for the checker */
   --col-code-pass: #31572c;
@@ -45,8 +49,12 @@ body.dark hr {
 }
 
 body.dark code {
-  background-color: var(--col-bg-400) !important;
-  color: var(--col-acc-500) !important;
+  background-color: var(--col-code-bg) !important;
+  color: var(--col-code-color) !important;
+}
+
+code {
+	background-color: var(--col-code-bg) !important;
 }
 
 body.dark table>thead {
@@ -267,7 +275,7 @@ body.dark a.list-group-item {
 }
 
 body.dark button.list-group-item {
-  color: var(--col-light-500) !important;
+  color: var(--col-light-800) !important;
 }
 
 body.dark .panel li.list-group-item {
@@ -694,7 +702,7 @@ body.dark .clean.well.gray {
 
 /* Evaluation styles */
 body.dark pre {
-  background-color: var(--col-bg-400) !important;
+  background-color: var(--col-code-bg) !important;
   border: none !important;
   filter: drop-shadow(0 0 1px var(--col-bg-400)) !important;
 }

--- a/css/alx-dark.css
+++ b/css/alx-dark.css
@@ -53,7 +53,7 @@ body.dark code {
   color: var(--col-code-color) !important;
 }
 
-code {
+dark code {
 	background-color: var(--col-code-bg) !important;
 }
 

--- a/css/alx-dark.css
+++ b/css/alx-dark.css
@@ -12,8 +12,7 @@
   --col-acc-500: #f36262;
 
   /* Code custom colors*/
-  --col-code-color: #DD9444;
-  --col-code-bg: #2B2D30;
+  --col-code-color: #e55039;
 
   /* Colors for the checker */
   --col-code-pass: #31572c;
@@ -49,7 +48,7 @@ body.dark hr {
 }
 
 body.dark code {
-  background-color: var(--col-code-bg) !important;
+  background-color: var(--col-bg-400) !important;
   color: var(--col-code-color) !important;
 }
 
@@ -275,7 +274,7 @@ body.dark a.list-group-item {
 }
 
 body.dark button.list-group-item {
-  color: var(--col-light-800) !important;
+	color: var(--col-light-500) !important;
 }
 
 body.dark .panel li.list-group-item {
@@ -702,9 +701,9 @@ body.dark .clean.well.gray {
 
 /* Evaluation styles */
 body.dark pre {
-  background-color: var(--col-code-bg) !important;
-  border: none !important;
-  filter: drop-shadow(0 0 1px var(--col-bg-400)) !important;
+	background-color: var(--col-bg-400) !important;
+	border: none !important;
+	filter: drop-shadow(0 0 1px var(--col-bg-400)) !important;
 }
 /* Evaluation styles ends here */
 


### PR DESCRIPTION
Code colors natively are red but in dark mode I think is very hard to see for a long time.
<img width="859" alt="Capture d’écran 2023-05-11 à 23 11 46" src="https://github.com/vinsky001/ALX-DarkMode-project/assets/63238348/d346deeb-219f-40f2-9851-508307c967b3">

I think that we can have better and readable text with this yellow. It is code yellow from slack dark mode.

<img width="859" alt="Capture d’écran 2023-05-11 à 23 25 07" src="https://github.com/vinsky001/ALX-DarkMode-project/assets/63238348/7c2a625c-798e-495f-b2b9-b926f7d255d8">



