### PR TITLE
Feature: Add a background color to current date

### DIFF
--- a/css/alx-dark.css
+++ b/css/alx-dark.css
@@ -7,6 +7,9 @@
   --col-bg-700: #313338;
   --col-bg-800: #383A40;
 
+  /* Bacground color for current date on the Events Calendar*/
+  --col-current-date: #ABA683;
+
   /* Accent colors */
   --col-acc-400: #df3e3e;
   --col-acc-500: #f36262;
@@ -446,7 +449,7 @@ body.dark .dhx_cal_container {
 }
 
 body.dark .dhx_now .dhx_month_body {
-  background-color: var(--col-bg-400) !important;
+  background-color: var(--col-current-date)!important;
 }
 
 body.dark .dhx_now .dhx_month_head {

--- a/css/alx-dark.css
+++ b/css/alx-dark.css
@@ -8,7 +8,7 @@
   --col-bg-800: #383A40;
 
   /* Bacground color for current date on the Events Calendar*/
-  --col-current-date: #beb992;
+  --col-current-date: #888672;
 
   /* Accent colors */
   --col-acc-400: #df3e3e;

--- a/css/alx-dark.css
+++ b/css/alx-dark.css
@@ -8,7 +8,7 @@
   --col-bg-800: #383A40;
 
   /* Bacground color for current date on the Events Calendar*/
-  --col-current-date: #ABA683;
+  --col-current-date: #beb992;
 
   /* Accent colors */
   --col-acc-400: #df3e3e;


### PR DESCRIPTION
The different background color can help the leaner easily identify the current date and event.

Below is a screenshot:

<img width="1334" alt="Screenshot 2023-07-02 at 12 03 18" src="https://github.com/vinsky001/ALX-DarkMode-project/assets/15633901/148c491e-a6f5-41d1-95e7-a7bb39268711">
