### PR TITLE
Joel current date feature

### DIFF
--- a/css/alx-dark.css
+++ b/css/alx-dark.css
@@ -8,7 +8,10 @@
   --col-bg-800: #383a40;
 
   /* Bacground color for current date on the Events Calendar */
-  --col-current-date: #888672;
+  --col-current-date: #121212;
+
+  /* Border color for current date on the Events Calendar */
+  --col-current-date-border: #38b000;
 
   /* Bacground color for project in second deadline */
   --col-second-deadline: #ff00002b;
@@ -455,8 +458,12 @@ body.dark .dhx_cal_container {
   filter: drop-shadow(0 1px 2px var(--col-bg-400)) !important;
 }
 
+body.dark .dhx_now{
+	background-color: var(--col-bg-400) !important;
+	border: 1px solid var(--col-current-date-border) !important;
+}
 body.dark .dhx_now .dhx_month_body {
-  background-color: var(--col-current-date) !important;
+	/*background-color: var(--col-bg-400) !important;*/
 }
 
 body.dark .dhx_now .dhx_month_head {

--- a/css/alx-dark.css
+++ b/css/alx-dark.css
@@ -7,8 +7,7 @@
   --col-bg-700: #313338;
   --col-bg-800: #383a40;
 
-  /* Bacground color for current date on the Events Calendar */
-  --col-current-date: #121212;
+
 
   /* Border color for current date on the Events Calendar */
   --col-current-date-border: #38b000;
@@ -459,11 +458,10 @@ body.dark .dhx_cal_container {
 }
 
 body.dark .dhx_now{
-	background-color: var(--col-bg-400) !important;
 	border: 1px solid var(--col-current-date-border) !important;
 }
 body.dark .dhx_now .dhx_month_body {
-	/*background-color: var(--col-bg-400) !important;*/
+	background-color: var(--col-bg-400) !important;
 }
 
 body.dark .dhx_now .dhx_month_head {


### PR DESCRIPTION
Added borderline colour to the calendar's current date

Feature:
added lime-green(--col-current-date-border) border colour to the current date on the
calendar to make it stand out when checking the calendar

Fix:
Changed the background for current date from #888672 to #121212(--col-bg-400) to  improve the visibility
of the current date and also make it look clean and consistent with the dark theme

Doc:
I made it easier for users to quickly identify the current date on the calender
as soon as they visit the calendar page

![current date screenshot](https://github.com/vinsky001/ALX-DarkMode-project/assets/40897081/4f90e0ff-bf02-431b-a043-c4863b7842fe)
