### PR TITLE
Apply dark mode to header by updating CSS selectors

### DIFF
--- a/css/alx-dark.css
+++ b/css/alx-dark.css
@@ -168,9 +168,10 @@ body.dark .logo {
   filter: invert(1) hue-rotate(180deg);
 }
 
-body.dark .navbar-header {
+body.dark .header {
   background-color: var(--col-bg-400) !important;
   filter: drop-shadow(0 0 5px var(--col-bg-500));
+  border-color: var(--col-bg-800) !important;
 }
 
 body.dark .navbar {


### PR DESCRIPTION
This PR resolves the issue where the header was not applying dark mode styling due to a change in CSS classes. Updated the CSS selectors to match the new class structure.
#### Changes:
- Adjusted CSS selectors targeting the header for dark mode.
- Verified the fix by testing the extension on the updated intranet.

Please review and merge. Let me know if any additional adjustments are needed!
fixes #42

![intranet alxswe com_](https://github.com/user-attachments/assets/0dc66c4b-2d97-4773-8397-abd1a61d6bfe)
